### PR TITLE
feat: ReporterContract can now be named

### DIFF
--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -224,9 +224,25 @@ export type FilteringOptions = {
 }
 
 /**
+ * Type for the reporter handler function
+ */
+export type ReporterHandlerContract = (
+  runner: Runner<any>,
+  emitter: Emitter
+) => void | Promise<void>
+
+/**
+ * Type for a named reporter object.
+ */
+export type NamedReporterContract = {
+  readonly name: string
+  handler: ReporterHandlerContract
+}
+
+/**
  * Test reporters must adhere to the following contract
  */
-export type ReporterContract = (runner: Runner<any>, emitter: Emitter) => void | Promise<void>
+export type ReporterContract = ReporterHandlerContract | NamedReporterContract
 
 /**
  * The test node inside the failure tree

--- a/src/Runner/index.ts
+++ b/src/Runner/index.ts
@@ -145,7 +145,11 @@ export class Runner<Context extends Record<any, any>> extends Macroable {
     this.boot()
 
     for (let reporter of this.reporters) {
-      await reporter(this, this.emitter)
+      if (typeof reporter === 'function') {
+        await reporter(this, this.emitter)
+      } else {
+        await reporter.handler(this, this.emitter)
+      }
     }
 
     await this.notifyStart()

--- a/test/runner/configure.spec.ts
+++ b/test/runner/configure.spec.ts
@@ -58,4 +58,17 @@ test.group('configure | runner', () => {
     runner.registerReporter(listReporter)
     assert.deepEqual(runner.reporters, new Set([listReporter]))
   })
+
+  test('register named reporter with runner', async (assert) => {
+    const emitter = new Emitter()
+
+    const runner = new Runner(emitter)
+    const listReporter: ReporterContract = {
+      name: 'list' as const,
+      handler: () => {},
+    }
+
+    runner.registerReporter(listReporter)
+    assert.deepEqual(runner.reporters, new Set([listReporter]))
+  })
 })

--- a/test/runner/execute.spec.ts
+++ b/test/runner/execute.spec.ts
@@ -140,4 +140,15 @@ test.group('execute | reporters', () => {
     assert.isNotNull(runnerEndEvent)
     assert.deepEqual(stack, ['list reporter open', 'test', 'test 1'])
   })
+
+  test('call named reporters handlers on start', async (assert) => {
+    assert.plan(1)
+
+    const listReporter = {
+      name: 'list',
+      handler: () => assert.isTrue(true),
+    }
+
+    new Runner(new Emitter()).registerReporter(listReporter).start()
+  })
 })


### PR DESCRIPTION
Linked to https://github.com/japa/runner/issues/23

So here, we just allow the "factory" function of a reporter to also return its name. So that we can reference it later.